### PR TITLE
Fix errors with paths containing spaces

### DIFF
--- a/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
+++ b/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
@@ -71,10 +71,10 @@ module Fastlane
         keystore_params = ''
 
         unless keystore_info.empty?
-          keystore_params = "--ks=#{keystore_info[:keystore_path]} --ks-pass=pass:#{keystore_info[:keystore_password]} --ks-key-alias=#{keystore_info[:alias]} --key-pass=pass:#{keystore_info[:alias_password]}"
+          keystore_params = "--ks=\"#{keystore_info[:keystore_path]}\" --ks-pass=pass:#{keystore_info[:keystore_password]} --ks-key-alias=#{keystore_info[:alias]} --key-pass=pass:#{keystore_info[:alias_password]}"
         end
 
-        cmd = "java -jar #{@bundletool_temp_path}/bundletool.jar build-apks --bundle=#{aab_path} --output=#{output_path} --mode=universal #{keystore_params}"
+        cmd = "java -jar #{@bundletool_temp_path}/bundletool.jar build-apks --bundle=\"#{aab_path}\" --output=\"#{output_path}\" --mode=universal #{keystore_params}"
 
         Open3.popen3(cmd) do |_, _, stderr, wait_thr|
           exit_status = wait_thr.value
@@ -94,9 +94,9 @@ module Fastlane
           puts_important("Creating path #{target_dir_name} since does not exist")
           FileUtils.mkdir_p target_dir_name
         end
-        cmd = "mv #{output_path} #{@bundletool_temp_path}/output.zip &&
-        unzip #{@bundletool_temp_path}/output.zip -d #{@bundletool_temp_path} &&
-        mv #{@bundletool_temp_path}/universal.apk #{target_path}"
+        cmd = "mv \"#{output_path}\" \"#{@bundletool_temp_path}/output.zip\" &&
+        unzip \"#{@bundletool_temp_path}/output.zip\" -d \"#{@bundletool_temp_path}\" &&
+        mv \"#{@bundletool_temp_path}/universal.apk\" \"#{target_path}\""
         Open3.popen3(cmd) do |_, _, stderr, wait_thr|
           exit_status = wait_thr.value
           raise stderr.read unless exit_status.success?

--- a/spec/bundletool_action_spec.rb
+++ b/spec/bundletool_action_spec.rb
@@ -35,4 +35,17 @@ describe 'BundletoolAction.run should' do
                                             aab_path: invalid_path,
                                             apk_output_path: '/resources/example.apk')
   end
+  
+  it 'works when .abb file path contains spaces' do
+    Dir.mktmpdir("foo bar") do |path_with_spaces|
+      FileUtils.cp('./resources/example.aab', path_with_spaces+'/example.aab')
+
+      Fastlane::Actions::BundletoolAction.run(verbose: true,
+                                              bundletool_version: '0.11.0',
+                                              aab_path: path_with_spaces+'/example.aab',
+                                              apk_output_path: path_with_spaces+'/example.apk')
+                                              
+      expect(File.exists? path_with_spaces+'/example.apk').to eq(true)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 
 require 'simplecov'
+require 'tmpdir'
 
 # SimpleCov.minimum_coverage 95
 SimpleCov.start


### PR DESCRIPTION
When invoking bundletool with a path containing spaces, it failed
because the command did not take into account that the path may contain
spaces.

When passing a path with a space on it, the shell interpreted the
space as a separation between parameters:
`bundletool --bundle /path/with/spaces on/it`

As the substring 'on/it' is considered a second parameter but because
it does not starts with '--' it generates the error:
"Error while parsing the flags: Syntax error: flags should start with --"

The solution is to add double quotes around the path variables when generating
the command string used to invoke bundletool or any other shell command.