### PR TITLE
fix: fix usage URI instead of deprecated Kernel

### DIFF
--- a/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
+++ b/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
@@ -42,7 +42,7 @@ module Fastlane
       def self.download_bundletool(version)
         puts_message("Downloading bundletool (#{version}) from https://github.com/google/bundletool/releases/download/#{version}/bundletool-all-#{version}.jar...")
         Dir.mkdir "#{@project_root}/bundletool_temp"        
-        Kernel.open("https://github.com/google/bundletool/releases/download/#{version}/bundletool-all-#{version}.jar") do |bundletool|
+        URI.open("https://github.com/google/bundletool/releases/download/#{version}/bundletool-all-#{version}.jar") do |bundletool|
           File.open("#{@bundletool_temp_path}/bundletool.jar", 'wb') do |file|
             file.write(bundletool.read)
           end


### PR DESCRIPTION
Hi, I tried your plugin, and have some problems.

When bundletool downloading, I have error:

`Something went wrong when downloading bundletool version 1.7.0. 
Error message
No such file or directory @ rb_sysopen`

It depends on installed ruby version. Before ruby 3.0.0, all works, but we see warning:

`warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open`

But after 3.0.0 `Kernel#open` finally not working for url, and now we must use only `URI#open` for download network links.

URI.open works for all ruby versions.