### PR TITLE
Added cache_path option to cache binary path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.0.8] - 2022-03-08
+- Added `cache_path` option to be able to cache bundletool binary. If `version` is used it will save the binary as bundletool_VERSION.jar and if you use `download_url` it will save it as bundletool_SHA_BASE_ON_URL.jar
+
+## [1.0.7] - 2022-02-16
+- Fix error when `verbose` is set to false.
+
 ## [1.0.6] - 2022-03-29
 - Adding a `download_url` option to point to a specific bundletool url. Thanks to @alienwizard
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ fastlane add_plugin bundletool
 or in your Pluginfile under fastlane folder write the following line and run `bundle install`.
 
 ```
-gem 'fastlane-plugin-bundletool', '1.0.6'
+gem 'fastlane-plugin-bundletool', '1.0.8'
 ```
 
 ## About bundletool
@@ -37,7 +37,8 @@ bundletool(
   bundletool_version: '1.10.0', # For searching a specific version of bundletool visit https://github.com/google/bundletool/releases
   aab_path: aab_path,
   apk_output_path: apk_output_path,
-  verbose: true
+  verbose: true,
+  cache_path: cache_path
 )
 ```
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,17 @@ lane :bundletool_test do
     verbose: true,
     bundletool_version: '1.10.0',
     aab_path: 'resources/example.aab',
-    apk_output_path: "resources/bundletool_temp/universal_apk/myapk.apk"
+    apk_output_path: "resources/bundletool_temp/universal_apk/myapk.apk",
+    cache_path: './.cache'
+  )
+end
+
+lane :bundletool_test_url do
+  bundletool(
+    verbose: true,
+    download_url: 'https://github.com/google/bundletool/releases/download/1.10.0/bundletool-all-1.10.0.jar',
+    aab_path: 'resources/example.aab',
+    apk_output_path: "resources/bundletool_temp/universal_apk/myapk.apk",
+    cache_path: './.cache'
   )
 end

--- a/lib/fastlane/plugin/bundletool/version.rb
+++ b/lib/fastlane/plugin/bundletool/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Bundletool
-    VERSION = "1.0.7"
+    VERSION = "1.0.8"
   end
 end


### PR DESCRIPTION
Added `cache_path` option to be able to cache bundletool binary. 

If `version` is used it will save the binary as **bundletool_VERSION.jar** and if you use `download_url` it will save it as **bundletool_SHA_BASE_ON_URL.jar**

If `cache_path` is not set, it will use the temporary folder that will be deleted after executing the action.