### PR TITLE
Add environment variables matching input parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased] - 2023-04-21
+- Added `env_name` to input parameters to be able to read variables from dotenv
+
 ## [1.0.8] - 2022-03-08
 - Added `cache_path` option to be able to cache bundletool binary. If `version` is used it will save the binary as bundletool_VERSION.jar and if you use `download_url` it will save it as bundletool_SHA_BASE_ON_URL.jar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [Unreleased] - 2023-04-21
-- Added `env_name` to input parameters to be able to read variables from dotenv
+## [1.0.9] - 2023-04-27
+- Added `env_name` to input parameters to be able to read variables from dotenv. Thanks to @txuslee
 
 ## [1.0.8] - 2022-03-08
 - Added `cache_path` option to be able to cache bundletool binary. If `version` is used it will save the binary as bundletool_VERSION.jar and if you use `download_url` it will save it as bundletool_SHA_BASE_ON_URL.jar

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ bundletool(
 
 This will output the universal `.apk` in the output path you set.
 
+## Options
+
+| Key                   | Description                                             | Env Var(s)                      | Default |
+|-----------------------|---------------------------------------------------------|---------------------------------|---------|
+| ks_path               | Path to .jks file                                       | FL_BUNDLETOOL_KEYSTORE_FILE     |         |
+| ks_password           | .jks password                                           | FL_BUNDLETOOL_KEYSTORE_PASSWORD |         |
+| ks_key_alias          | Alias for jks                                           | FL_BUNDLETOOL_KEY_ALIAS         |         |
+| ks_key_alias_password | Alias password for .jks                                 | FL_BUNDLETOOL_KEY_PASSWORD      |         |
+| bundletool_version    | Version of bundletool to use, by default 0.11.0 will    | FL_BUNDLETOOL_VERSION           | 0.11.0  |
+|                       | be used                                                 |                                 |         |
+| download_url          | Url to download bundletool from, should point to a jar  | FL_BUNDLETOOL_DOWNLOAD_URL      |         |
+|                       | file                                                    |                                 |         |
+| aab_path              | Path where the aab file is                              | FL_BUNDLETOOL_AAB_PATH          |         |
+| apk_output_path       | Path where the apk file is going to be placed           | FL_BUNDLETOOL_APK_OUTPUT_PATH   | .       |
+| verbose               | Show every messages of the action                       | FL_BUNDLETOOL_VERBOSE           | false   |
+| cache_path            | Cache downloaded bundletool binary into the cache path  | FL_BUNDLETOOL_CACHE_PATH        |         |
+|-----------------------|---------------------------------------------------------|---------------------------------|---------|
+
 ## Use case
 
 Here you can find a post I did explaining why I have to create this action.

--- a/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
+++ b/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
@@ -158,12 +158,12 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :ks_path,
-                                       env_name: 'FL_BUNDLETOOL_STORE_FILE',
+                                       env_name: 'FL_BUNDLETOOL_KEYSTORE_FILE',
                                        description: 'Path to .jks file',
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :ks_password,
-                                       env_name: 'FL_BUNDLETOOL_STORE_PASSWORD',
+                                       env_name: 'FL_BUNDLETOOL_KEYSTORE_PASSWORD',
                                        description: '.jks password',
                                        is_string: true,
                                        optional: true),

--- a/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
+++ b/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
@@ -158,30 +158,37 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :ks_path,
+                                       env_name: 'FL_BUNDLETOOL_STORE_FILE',
                                        description: 'Path to .jks file',
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :ks_password,
+                                       env_name: 'FL_BUNDLETOOL_STORE_PASSWORD',
                                        description: '.jks password',
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :ks_key_alias,
+                                       env_name: 'FL_BUNDLETOOL_KEY_ALIAS',
                                        description: 'Alias for jks',
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :ks_key_alias_password,
+                                       env_name: 'FL_BUNDLETOOL_KEY_PASSWORD',
                                        description: 'Alias password for .jks',
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :bundletool_version,
+                                       env_name: 'FL_BUNDLETOOL_VERSION',
                                        description: 'Version of bundletool to use, by default 0.11.0 will be used',
                                        is_string: true,
                                        default_value: '0.11.0'),
           FastlaneCore::ConfigItem.new(key: :download_url,
+                                       env_name: 'FL_BUNDLETOOL_DOWNLOAD_URL',
                                        description: 'Url to download bundletool from, should point to a jar file',
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :aab_path,
+                                       env_name: 'FL_BUNDLETOOL_AAB_PATH',
                                        description: 'Path where the aab file is',
                                        is_string: true,
                                        optional: false,
@@ -191,21 +198,23 @@ module Fastlane
                                          end
                                        end),
           FastlaneCore::ConfigItem.new(key: :apk_output_path,
+                                       env_name: 'FL_BUNDLETOOL_APK_OUTPUT_PATH',
                                        description: 'Path where the apk file is going to be placed',
                                        is_string: true,
                                        optional: true,
                                        default_value: '.'),
           FastlaneCore::ConfigItem.new(key: :verbose,
+                                       env_name: 'FL_BUNDLETOOL_VERBOSE',
                                        description: 'Show every messages of the action',
                                        is_string: false,
                                        type: Boolean,
                                        optional: true,
                                        default_value: false),
-            FastlaneCore::ConfigItem.new(key: :cache_path,
+          FastlaneCore::ConfigItem.new(key: :cache_path,
+                                       env_name: 'FL_BUNDLETOOL_CACHE_PATH',
                                        description: 'Cache downloaded bundletool binary into the cache path specified',
-                                       is_string: true,                                       
+                                       is_string: true,
                                        optional: true)
-
         ]
       end
 
@@ -239,7 +248,7 @@ module Fastlane
           puts_message("Using binary cached at #{installation_path}/#{bundletool_filename}")
           return
         end
-        
+
         puts_message("Downloading bundletool from #{download_url}")
 
         URI.open(download_url) do |bundletool|

--- a/lib/fastlane/plugin/bundletool/version.rb
+++ b/lib/fastlane/plugin/bundletool/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Bundletool
-    VERSION = "1.0.8"
+    VERSION = "1.0.9"
   end
 end


### PR DESCRIPTION
Thanks for this excellent Fastlane plugin! It really helped us having the download of the `bundletool` integrated in the action.

I missed to have matching environment variables assigned to each of the parameters, so I thought I could contribute adding them.

In this way you can now define the variables needed in a dotenv `.env` file like:

```
FL_BUNDLETOOL_STORE_FILE=<...>
FL_BUNDLETOOL_STORE_PASSWORD=<...>
FL_BUNDLETOOL_KEY_ALIAS=<...>
FL_BUNDLETOOL_KEY_PASSWORD=<...>
FL_BUNDLETOOL_VERSION=1.14.1
FL_BUNDLETOOL_AAB_PATH=<...>
FL_BUNDLETOOL_APK_OUTPUT_PATH=<...>
FL_BUNDLETOOL_VERBOSE=true
FL_BUNDLETOOL_CACHE_PATH=<...>
```

And just call the action with or without parameters if you need to override environment variables:

```
bundletool(aab_path:  lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH])
```

**EDIT:**

Updated keystore variable names as suggested from:
```
FL_BUNDLETOOL_STORE_FILE=<...>
FL_BUNDLETOOL_STORE_PASSWORD=<...>
```
into
```
FL_BUNDLETOOL_KEYSTORE_FILE=<...>
FL_BUNDLETOOL_KEYSTORE_PASSWORD=<...>
```