### PR TITLE
fix: handle special characters

### DIFF
--- a/fastlane-plugin-bundletool.gemspec
+++ b/fastlane-plugin-bundletool.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rubocop-require_tools', '~> 0.1.2')
   spec.add_development_dependency('simplecov', '~> 0.12.0')
   spec.add_development_dependency('fastlane', '>= 2.137.0')
+  spec.add_development_dependency('shellwords', '~> 0.2.0')
 end

--- a/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
+++ b/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'fastlane/action'
+require 'shellwords'
 require_relative '../helper/bundletool_helper'
 
 module Fastlane
@@ -93,7 +94,10 @@ module Fastlane
         keystore_params = ''
 
         unless keystore_info.empty?
-          keystore_params = "--ks='#{keystore_info[:keystore_path]}' --ks-pass='pass:#{keystore_info[:keystore_password]}' --ks-key-alias='#{keystore_info[:alias]}' --key-pass='pass:#{keystore_info[:alias_password]}'"
+          key_alias_password = Shellwords.shellescape("pass:#{keystore_info[:alias_password]}")
+          key_store_password = Shellwords.shellescape("pass:#{keystore_info[:keystore_password]}")
+          key_alias = Shellwords.shellescape(keystore_info[:alias])
+          keystore_params = "--ks=#{keystore_info[:keystore_path]} --ks-pass=#{key_store_password} --ks-key-alias=#{key_alias} --key-pass=#{key_alias_password}"
         end
 
         cmd = "java -jar #{installation_path}/#{bundletool_filename} build-apks --bundle=\"#{aab_path}\" --output=\"#{output_path}\" --mode=universal #{keystore_params}"

--- a/lib/fastlane/plugin/bundletool/version.rb
+++ b/lib/fastlane/plugin/bundletool/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Bundletool
-    VERSION = "1.0.9"
+    VERSION = "1.0.10"
   end
 end

--- a/spec/bundletool_action_spec.rb
+++ b/spec/bundletool_action_spec.rb
@@ -49,4 +49,22 @@ describe 'BundletoolAction.run should' do
       expect(File.exists? path_with_spaces+'/example.apk').to eq(true)
     end
   end
+
+  it 'handles single quote key-alias passwords' do
+    expect {
+      Fastlane::Actions::BundletoolAction.run(verbose: true,
+                                              bundletool_version: '0.11.0',
+                                              aab_path: 'resources/example.aab',
+                                              apk_output_path: 'resources/example.apk',
+                                              ks_path: 'resources/android-invalid.keystore',
+                                              ks_password: "ab'9{8{7c",
+                                              ks_key_alias: 'testing',
+                                              ks_key_alias_password: "ab'9{8{7c"
+                                             )
+    }.to raise_error do |error|
+      expect(error.message).not_to include("Error: Flag --ks-key-alias is required when --ks is set")
+      expect(error.message).to include("Error: File 'resources/android-invalid.keystore' was not found")
+    end                              
+    expect(File.exists? 'resources/example.apk').to eq(true)
+    end
 end


### PR DESCRIPTION
Use `Shellwords` to properly escape special characters, the current implementation meant passwords could not contain single quotes, creating the following error.

```
 sh: -c: line 0: unexpected EOF while looking for matching `''
sh: -c: line 1: syntax error: unexpected end of file
```

Adds test to check that these special characters are not causing errors. 