### PR TITLE
fix: multiline string cmd for prepare_apk

### DIFF
--- a/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
+++ b/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
@@ -120,9 +120,11 @@ module Fastlane
           puts_important("Creating path #{target_dir_name} since does not exist")
           FileUtils.mkdir_p target_dir_name
         end
-        cmd = "mv \"#{output_path}\" \"#{@bundletool_temp_path}/output.zip\" &&
-        unzip \"#{@bundletool_temp_path}/output.zip\" -d \"#{@bundletool_temp_path}\" &&
-        mv \"#{@bundletool_temp_path}/universal.apk\" \"#{target_path}\""
+
+        cmd = "mv \"#{output_path}\" \"#{@bundletool_temp_path}/output.zip\" &&"\
+              "unzip \"#{@bundletool_temp_path}/output.zip\" -d \"#{@bundletool_temp_path}\" &&"\
+              "mv \"#{@bundletool_temp_path}/universal.apk\" \"#{target_path}\""
+
         Open3.popen3(cmd) do |_, _, stderr, wait_thr|
           exit_status = wait_thr.value
           raise stderr.read unless exit_status.success?


### PR DESCRIPTION
Hello!

If running the bundletool fastlane plugin on Windows cmd, you get an error - `The syntax of the command is incorrect.`. The reason is that putting new lines in the ruby string creates new lines in the output, and this can lead to inconsistent run in some shells.

When using `\` we ensure that the resulting command is a single line.