### PR TITLE
fix: use single quotes in keystore path to handle paths containing spaces

### DIFF
--- a/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
+++ b/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
@@ -97,7 +97,7 @@ module Fastlane
           key_alias_password = Shellwords.shellescape("pass:#{keystore_info[:alias_password]}")
           key_store_password = Shellwords.shellescape("pass:#{keystore_info[:keystore_password]}")
           key_alias = Shellwords.shellescape(keystore_info[:alias])
-          keystore_params = "--ks=#{keystore_info[:keystore_path]} --ks-pass=#{key_store_password} --ks-key-alias=#{key_alias} --key-pass=#{key_alias_password}"
+          keystore_params = "--ks='#{keystore_info[:keystore_path]}' --ks-pass=#{key_store_password} --ks-key-alias=#{key_alias} --key-pass=#{key_alias_password}"
         end
 
         cmd = "java -jar #{installation_path}/#{bundletool_filename} build-apks --bundle=\"#{aab_path}\" --output=\"#{output_path}\" --mode=universal #{keystore_params}"


### PR DESCRIPTION
In the version v1.0.10 the single quotes in the keystore path parameter were removed introducing the bug. 

When the keystore path contains spaces the path is split and taken as multiple parameters, at least in Linux.