### PR TITLE
fix: fall back to GRADLE_AAB_OUTPUT_PATH lane_context

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -3,7 +3,7 @@ description: 'Setup Ruby environment and install dependencies'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile') }}

--- a/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
+++ b/lib/fastlane/plugin/bundletool/actions/bundletool_action.rb
@@ -22,10 +22,15 @@ module Fastlane
 
         bundletool_version = params[:bundletool_version]
         download_url = params[:download_url]
-        aab_path = params[:aab_path]
+        aab_path = params[:aab_path] || Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
         output_path = params[:apk_output_path] || '.'
         cache_path = params[:cache_path]
         universal_apk = params[:universal_apk]
+
+        if aab_path.nil? || aab_path.empty?
+          puts_error!('You must set aab_path or have GRADLE_AAB_OUTPUT_PATH set in lane_context.')
+          return
+        end
 
         return unless validate_aab!(aab_path)
 
@@ -203,14 +208,9 @@ module Fastlane
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :aab_path,
                                        env_name: 'FL_BUNDLETOOL_AAB_PATH',
-                                       description: 'Path where the aab file is',
+                                       description: 'Path where the aab file is. Falls back to lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH] when not provided',
                                        is_string: true,
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         unless value && !value.empty?
-                                           UI.user_error!('You must set aab_path.')
-                                         end
-                                       end),
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :apk_output_path,
                                        env_name: 'FL_BUNDLETOOL_APK_OUTPUT_PATH',
                                        description: 'Path where the apk file is going to be placed',

--- a/spec/bundletool_action_spec.rb
+++ b/spec/bundletool_action_spec.rb
@@ -50,7 +50,7 @@ describe 'BundletoolAction.run should' do
     end
   end
 
-  it 'handles single quote key-alias passwords' do  
+  it 'handles single quote key-alias passwords' do
       Fastlane::Actions::BundletoolAction.run(verbose: true,
                                               bundletool_version: '0.11.0',
                                               aab_path: 'resources/example.aab',
@@ -61,5 +61,57 @@ describe 'BundletoolAction.run should' do
                                               ks_key_alias_password: "ab'9{8{7c")
 
       expect(File.exist? 'resources/example.apk').to eq(true)
+  end
+
+  context 'aab_path fallback to lane_context' do
+    before do
+      Fastlane::Actions.lane_context.delete(Fastlane::Actions::SharedValues::GRADLE_AAB_OUTPUT_PATH)
+    end
+
+    after do
+      Fastlane::Actions.lane_context.delete(Fastlane::Actions::SharedValues::GRADLE_AAB_OUTPUT_PATH)
+    end
+
+    it 'falls back to GRADLE_AAB_OUTPUT_PATH lane_context when aab_path is not provided' do
+      lane_aab_path = 'lane/context/example.aab'
+      lane_aab_absolute_path = Pathname.new(File.expand_path(lane_aab_path)).to_s
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_AAB_OUTPUT_PATH] = lane_aab_path
+
+      bundletool_url = 'https://github.com/google/bundletool/releases/download/0.11.0/bundletool-all-0.11.0.jar'
+      error = 'error'
+      allow(File).to receive(:file?).with(lane_aab_path).and_return(true)
+      allow(Kernel).to receive(:open).with(bundletool_url).and_return('somebody')
+      allow(Fastlane::Actions::BundletoolAction).to receive(:run_bundletool!).and_raise(StandardError.new(error))
+
+      expect(FastlaneCore::UI).to receive(:user_error!).with("Bundletool could not extract universal apk from aab at #{lane_aab_absolute_path}. \nError message\n #{error}")
+
+      Fastlane::Actions::BundletoolAction.run(verbose: true,
+                                              bundletool_version: '0.11.0')
+    end
+
+    it 'prefers explicit aab_path over GRADLE_AAB_OUTPUT_PATH lane_context' do
+      explicit_aab_path = 'explicit/example.aab'
+      explicit_absolute_path = Pathname.new(File.expand_path(explicit_aab_path)).to_s
+      Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::GRADLE_AAB_OUTPUT_PATH] = 'lane/context/example.aab'
+
+      bundletool_url = 'https://github.com/google/bundletool/releases/download/0.11.0/bundletool-all-0.11.0.jar'
+      error = 'error'
+      allow(File).to receive(:file?).with(explicit_aab_path).and_return(true)
+      allow(Kernel).to receive(:open).with(bundletool_url).and_return('somebody')
+      allow(Fastlane::Actions::BundletoolAction).to receive(:run_bundletool!).and_raise(StandardError.new(error))
+
+      expect(FastlaneCore::UI).to receive(:user_error!).with("Bundletool could not extract universal apk from aab at #{explicit_absolute_path}. \nError message\n #{error}")
+
+      Fastlane::Actions::BundletoolAction.run(verbose: true,
+                                              bundletool_version: '0.11.0',
+                                              aab_path: explicit_aab_path)
+    end
+
+    it 'errors when neither aab_path nor GRADLE_AAB_OUTPUT_PATH lane_context is set' do
+      expect(FastlaneCore::UI).to receive(:user_error!).with('You must set aab_path or have GRADLE_AAB_OUTPUT_PATH set in lane_context.')
+
+      Fastlane::Actions::BundletoolAction.run(verbose: true,
+                                              bundletool_version: '0.11.0')
+    end
   end
 end


### PR DESCRIPTION
Fixex https://github.com/MartinGonzalez/fastlane-plugin-bundletool/issues/29

Make `aab_path` optional and fall back to `Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]` when not provided. Callers that just ran the gradle build no longer need to pass the AAB path explicitly. Errors with a clear message when neither is set.

#### Action points
`aab_path` ConfigItem is now `optional: true` (was  `optional: false` with a `verify_block`). Backwards compatible — explicit `aab_path` still takes precedence over the lane_context value.